### PR TITLE
cs/deletion - Added deletion of challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install
 npm install -g dotenv-cli
 ```
 
-5. Add a `.env` and `.env.test` file it your root with the following configurations:
+5. Add a `.env` and `.env.test` file in your root with the following configurations:
 
 ```bash
 PORT=3000

--- a/app/challenges-platform/models/Challenge.ts
+++ b/app/challenges-platform/models/Challenge.ts
@@ -8,6 +8,7 @@ export enum Evaluation {
   MANUAL,
   AUTOMATIC,
 }
+
 export class Challenge {
   id: number;
   uuid: string;
@@ -16,7 +17,7 @@ export class Challenge {
   format: Format;
   evaluation: Evaluation;
   points: number;
-  deleted: string;
+  deleted: boolean;
 
   constructor({
     id,
@@ -35,7 +36,7 @@ export class Challenge {
     format: Format;
     evaluation: Evaluation;
     points: number;
-    deleted: string,
+    deleted: boolean;
   }) {
     this.id = id;
     this.uuid = uuid;

--- a/app/challenges-platform/models/Challenge.ts
+++ b/app/challenges-platform/models/Challenge.ts
@@ -16,6 +16,7 @@ export class Challenge {
   format: Format;
   evaluation: Evaluation;
   points: number;
+  deleted: string;
 
   constructor({
     id,
@@ -25,6 +26,7 @@ export class Challenge {
     format,
     evaluation,
     points,
+    deleted,
   }: {
     id: number;
     uuid: string;
@@ -33,6 +35,7 @@ export class Challenge {
     format: Format;
     evaluation: Evaluation;
     points: number;
+    deleted: string,
   }) {
     this.id = id;
     this.uuid = uuid;
@@ -41,5 +44,6 @@ export class Challenge {
     this.format = format;
     this.evaluation = evaluation;
     this.points = points;
+    this.deleted = deleted;
   }
 }

--- a/app/challenges-platform/models/Transformer.ts
+++ b/app/challenges-platform/models/Transformer.ts
@@ -34,7 +34,7 @@ export class BaseTransformer extends Transformer {
       format: Format.TEXT,
       points: payload.points,
       evaluation: Evaluation.MANUAL,
-      deleted: Boolean(payload.deleted),
+      deleted: payload.deleted,
     });
     return challenge;
   }

--- a/app/challenges-platform/models/Transformer.ts
+++ b/app/challenges-platform/models/Transformer.ts
@@ -34,7 +34,7 @@ export class BaseTransformer extends Transformer {
       format: Format.TEXT,
       points: payload.points,
       evaluation: Evaluation.MANUAL,
-      deleted: payload.deleted,
+      deleted: Boolean(payload.deleted),
     });
     return challenge;
   }

--- a/app/challenges-platform/models/Transformer.ts
+++ b/app/challenges-platform/models/Transformer.ts
@@ -34,6 +34,7 @@ export class BaseTransformer extends Transformer {
       format: Format.TEXT,
       points: payload.points,
       evaluation: Evaluation.MANUAL,
+      deleted: payload.deleted,
     });
     return challenge;
   }

--- a/app/challenges-platform/services/challenges-service.ts
+++ b/app/challenges-platform/services/challenges-service.ts
@@ -71,8 +71,18 @@ export const update = async (): Promise<Result<Challenge, Error>> => {
   return Err(new Error("Not implemented"));
 };
 
-export const destroy = async (): Promise<Result<Challenge, Error>> => {
+export const destroy = async (id: string): Promise<Result<Challenge, Error>> => {
   // TODO: should mark a challenge as deleted (soft delete)
-  // TODO: add a "deleted" boolean column to the challenges table
-  return Err(new Error("Not implemented"));
+  try {
+    const result = await db
+      .update(challenges)
+      .set({ deleted: "TRUE" })
+      .where(eq(challenges.uuid, id))
+      .returning();
+    const transformer = challengesPlatform.findTransformer(result[0].type);
+    const challenge = transformer.newChallenge(result[0]);
+    return Ok(challenge);
+  } catch (e) {
+    return Err(new Error("Failed to mark challenge as deleted"));
+  }
 };

--- a/app/challenges-platform/services/challenges-service.ts
+++ b/app/challenges-platform/services/challenges-service.ts
@@ -74,11 +74,10 @@ export const update = async (): Promise<Result<Challenge, Error>> => {
 export const destroy = async (
   id: string,
 ): Promise<Result<Challenge, Error>> => {
-  // TODO: should mark a challenge as deleted (soft delete)
   try {
     const result = await db
       .update(challenges)
-      .set({ deleted: Number(true) })
+      .set({ deleted: true })
       .where(eq(challenges.uuid, id))
       .returning();
     const transformer = challengesPlatform.findTransformer(result[0].type);

--- a/app/challenges-platform/services/challenges-service.ts
+++ b/app/challenges-platform/services/challenges-service.ts
@@ -71,12 +71,14 @@ export const update = async (): Promise<Result<Challenge, Error>> => {
   return Err(new Error("Not implemented"));
 };
 
-export const destroy = async (id: string): Promise<Result<Challenge, Error>> => {
+export const destroy = async (
+  id: string,
+): Promise<Result<Challenge, Error>> => {
   // TODO: should mark a challenge as deleted (soft delete)
   try {
     const result = await db
       .update(challenges)
-      .set({ deleted: "TRUE" })
+      .set({ deleted: Number(true) })
       .where(eq(challenges.uuid, id))
       .returning();
     const transformer = challengesPlatform.findTransformer(result[0].type);

--- a/app/challenges-platform/services/submissions-service.ts
+++ b/app/challenges-platform/services/submissions-service.ts
@@ -16,6 +16,9 @@ export const create = async (
   if (!challengeResult.ok) {
     return Err(new Error("Failed to find challenge"));
   }
+  if (challengeResult.val.deleted === "TRUE") {
+    return Err(new Error("Challenge is deleted"));
+  }
   const participantResult = await ParticipantsService.findByUuid(participantId);
   if (!participantResult.ok) {
     return Err(new Error("Failed to find participant"));

--- a/app/challenges-platform/services/submissions-service.ts
+++ b/app/challenges-platform/services/submissions-service.ts
@@ -16,7 +16,7 @@ export const create = async (
   if (!challengeResult.ok) {
     return Err(new Error("Failed to find challenge"));
   }
-  if (challengeResult.val.deleted === "TRUE") {
+  if (challengeResult.val.deleted === true) {
     return Err(new Error("Challenge is deleted"));
   }
   const participantResult = await ParticipantsService.findByUuid(participantId);

--- a/app/event-management/models/FlagChallenge.ts
+++ b/app/event-management/models/FlagChallenge.ts
@@ -55,7 +55,7 @@ export class FlagChallenge extends Challenge {
       format,
       points,
       evaluation: Evaluation.AUTOMATIC,
-      deleted: "FALSE",
+      deleted: false,
     });
     this.flag = flag;
   }

--- a/app/event-management/models/FlagChallenge.ts
+++ b/app/event-management/models/FlagChallenge.ts
@@ -55,6 +55,7 @@ export class FlagChallenge extends Challenge {
       format,
       points,
       evaluation: Evaluation.AUTOMATIC,
+      deleted: "FALSE",
     });
     this.flag = flag;
   }

--- a/app/event-management/models/GithubIssueChallenge.ts
+++ b/app/event-management/models/GithubIssueChallenge.ts
@@ -54,6 +54,7 @@ export class GithubIssueChallenge extends Challenge {
       format: Format.MARKDOWN,
       points,
       evaluation: Evaluation.MANUAL,
+      deleted: "FALSE",
     });
   }
 }

--- a/app/event-management/models/GithubIssueChallenge.ts
+++ b/app/event-management/models/GithubIssueChallenge.ts
@@ -54,7 +54,7 @@ export class GithubIssueChallenge extends Challenge {
       format: Format.MARKDOWN,
       points,
       evaluation: Evaluation.MANUAL,
-      deleted: "FALSE",
+      deleted: false,
     });
   }
 }

--- a/app/event-management/models/PhotoChallenge.ts
+++ b/app/event-management/models/PhotoChallenge.ts
@@ -52,6 +52,7 @@ export class PhotoChallenge extends Challenge {
       format,
       points,
       evaluation: Evaluation.MANUAL,
+      deleted: "FALSE",
     });
   }
 }

--- a/app/event-management/models/PhotoChallenge.ts
+++ b/app/event-management/models/PhotoChallenge.ts
@@ -52,7 +52,7 @@ export class PhotoChallenge extends Challenge {
       format,
       points,
       evaluation: Evaluation.MANUAL,
-      deleted: "FALSE",
+      deleted: false,
     });
   }
 }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -11,7 +11,7 @@ export const challenges = sqliteTable("challenges", {
   metadata: text("metadata", { mode: "json" }),
   createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
   updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
-  deleted: integer("deleted").notNull().default(0),
+  deleted: integer("deleted", { mode: "boolean" }).notNull().default(false),
 });
 
 export const participants = sqliteTable("participants", {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -11,7 +11,7 @@ export const challenges = sqliteTable("challenges", {
   metadata: text("metadata", { mode: "json" }),
   createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
   updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
-  deleted: text("deleted").notNull().default("FALSE"),
+  deleted: integer("deleted").notNull().default(0),
 });
 
 export const participants = sqliteTable("participants", {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -11,6 +11,7 @@ export const challenges = sqliteTable("challenges", {
   metadata: text("metadata", { mode: "json" }),
   createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
   updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
+  deleted: text("deleted").notNull().default("FALSE"),
 });
 
 export const participants = sqliteTable("participants", {

--- a/test/challenges-platform/custom-transformer.ts
+++ b/test/challenges-platform/custom-transformer.ts
@@ -62,6 +62,7 @@ export class CustomChallenge extends Challenge {
       format,
       points,
       evaluation: Evaluation.MANUAL,
+      deleted: "FALSE",
     });
     this.propString = propString;
     this.propNumber = propNumber;

--- a/test/challenges-platform/custom-transformer.ts
+++ b/test/challenges-platform/custom-transformer.ts
@@ -62,7 +62,7 @@ export class CustomChallenge extends Challenge {
       format,
       points,
       evaluation: Evaluation.MANUAL,
-      deleted: "FALSE",
+      deleted: false,
     });
     this.propString = propString;
     this.propNumber = propNumber;

--- a/test/challenges-platform/services/challenges-service.test.ts
+++ b/test/challenges-platform/services/challenges-service.test.ts
@@ -61,8 +61,8 @@ describe("ChallengesService", () => {
 
       const result = await ChallengesService.destroy(challenge.uuid);
 
-      if(!result.ok) fail("Expected result to be Ok");
-      expect(result.val.deleted).toBe("TRUE");
+      if (!result.ok) fail("Expected result to be Ok");
+      expect(result.val.deleted).toBe(true);
     });
   });
 

--- a/test/challenges-platform/services/challenges-service.test.ts
+++ b/test/challenges-platform/services/challenges-service.test.ts
@@ -57,9 +57,12 @@ describe("ChallengesService", () => {
 
   describe("destroy", () => {
     it("throws an error", async () => {
-      const result = await ChallengesService.destroy();
+      const challenge = await challengeFactory();
 
-      expect(result.err).toBe(true);
+      const result = await ChallengesService.destroy(challenge.uuid);
+
+      if(!result.ok) fail("Expected result to be Ok");
+      expect(result.val.deleted).toBe("TRUE");
     });
   });
 

--- a/test/challenges-platform/services/submissions-service.test.ts
+++ b/test/challenges-platform/services/submissions-service.test.ts
@@ -1,4 +1,5 @@
-import { SubmissionService } from "../../../app/challenges-platform";
+import { ChallengesService, SubmissionService } from "../../../app/challenges-platform";
+import { Challenge } from "../../../app/challenges-platform/models";
 import { challengeFactory } from "../factories/challenge-factory";
 import { participantFactory } from "../factories/participant-factory";
 
@@ -30,6 +31,24 @@ describe("SubmissionService", () => {
 
         expect(result.err).toBe(true);
         expect(result.val.toString()).toBe("Error: Failed to find challenge");
+      });
+    });
+    describe("when challenge is deleted", () => {
+      it("returns an error", async () => {
+        const factory = await challengeFactory();
+        // Delete the challenge
+        const challenge = await ChallengesService.destroy(factory.uuid);
+        if (!challenge.ok) fail("Expected challenge to be Ok, something went really wrong");
+
+        const participant = await participantFactory();
+
+        const result = await SubmissionService.create(
+          challenge.val.uuid,
+          participant.uuid,
+        );
+
+        expect(result.err).toBe(true);
+        expect(result.val.toString()).toBe("Error: Challenge is deleted");
       });
     });
     describe("when participant does not exist", () => {

--- a/test/challenges-platform/services/submissions-service.test.ts
+++ b/test/challenges-platform/services/submissions-service.test.ts
@@ -1,4 +1,7 @@
-import { ChallengesService, SubmissionService } from "../../../app/challenges-platform";
+import {
+  ChallengesService,
+  SubmissionService,
+} from "../../../app/challenges-platform";
 import { Challenge } from "../../../app/challenges-platform/models";
 import { challengeFactory } from "../factories/challenge-factory";
 import { participantFactory } from "../factories/participant-factory";
@@ -38,7 +41,8 @@ describe("SubmissionService", () => {
         const factory = await challengeFactory();
         // Delete the challenge
         const challenge = await ChallengesService.destroy(factory.uuid);
-        if (!challenge.ok) fail("Expected challenge to be Ok, something went really wrong");
+        if (!challenge.ok)
+          fail("Expected challenge to be Ok, something went really wrong");
 
         const participant = await participantFactory();
 

--- a/test/challenges-platform/services/submissions-service.test.ts
+++ b/test/challenges-platform/services/submissions-service.test.ts
@@ -2,7 +2,6 @@ import {
   ChallengesService,
   SubmissionService,
 } from "../../../app/challenges-platform";
-import { Challenge } from "../../../app/challenges-platform/models";
 import { challengeFactory } from "../factories/challenge-factory";
 import { participantFactory } from "../factories/participant-factory";
 


### PR DESCRIPTION
Resolves #2

* Added a new column in the db to store deletion status as a notNull integer.
* Modified challenge object schemes and transformer to store the deletion status when read from the db as a Boolean.
* Modified challenge service with deleted flag and added a check in submission service to prevent submission to deleted challenges.
* Added jest tests for changes as necessary.
* Corrected spelling error in README and ran formatter.